### PR TITLE
Add prompt examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Codex-hive does not run code for you. It provides the scaffolding so humans can 
 - `codex/` – policies, direction, and memory for the agents
 - `codex/roles/` – individual role definitions
 - `docs/` – human-facing guides and examples (see `docs/ONBOARDING.md`)
+- `docs/PROMPTS.md` – sample prompts for interacting with Codex roles
 - `LICENSE.lic` – released under the Unlicense
 
 Use `docs/direction.example.md` as inspiration for your own project direction. Log every meaningful change to `codex/progress.md` as you build.

--- a/codex/progress.md
+++ b/codex/progress.md
@@ -7,3 +7,6 @@
 ---
 - [reviewed] codex/direction.md – still aligned with repository goals
 - [reviewed] codex/roles/ – definitions adequate
+
+- [added] docs/PROMPTS.md – sample role activation prompts
+- [updated] README.md – referenced PROMPTS guide

--- a/docs/PROMPTS.md
+++ b/docs/PROMPTS.md
@@ -1,0 +1,49 @@
+# Prompt Examples for Codex-Hive
+
+These examples show how to interact with a Codex-based system that uses the Hive structure. They are starting points – adapt them to your project and policies.
+
+---
+
+## 1. Activate Roles
+
+Explicitly tell Codex which roles to involve when you want a specific mindset.
+
+```
+You are Orchestrator and DocWriter. Summarize the last commit and propose documentation updates.
+```
+
+## 2. Ask for a Plan
+
+When facing a new feature or problem, call on Planner first.
+
+```
+Frontman: We need a small CLI to list open tasks. What steps should we take?
+```
+
+## 3. Enforce Policy
+
+Remind Codex of the rules defined in `codex/policy.md` whenever you sense drift.
+
+```
+Guardian, verify the proposed change follows our policy about documentation and tests.
+```
+
+## 4. Trigger Reflection
+
+Use reflection prompts when the system grows complex or decisions feel uncertain.
+
+```
+Orchestrator, pause and summarize what decisions led to the current direction.
+```
+
+## 5. Safety Check
+
+Before merging or executing high-impact changes, ask for a safety review.
+
+```
+Guardian and Planner: are there any risks or missing context before we proceed with deployment scripts?
+```
+
+---
+
+These prompts are intentionally lightweight. The goal is to keep conversations transparent and role-aware. Modify them to fit your workflow and keep policy in mind.


### PR DESCRIPTION
## Summary
- add a new guide with prompt examples for Codex roles
- mention the prompt guide in README
- log the addition in codex/progress

## Testing
- `git status --short`