### PR TITLE
Add project scaffolding CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ Use `docs/direction.example.md` as inspiration for your own project direction. L
 
 Codex-hive is an independent, open-source project. It is **not affiliated with OpenAI** and carries no official endorsement. The name "Codex" references OpenAI's technology but does not imply partnership.
 
+
+## Quick Start
+
+Use the provided script to scaffold a new project based on codex-hive:
+
+```bash
+./cli/init.sh my-new-project
+```
+
+See `docs/CLI_INIT.md` for details.
+
+

--- a/cli/init.sh
+++ b/cli/init.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# codex-hive CLI - initialize a new Codex-based project
+
+set -e
+
+TARGET_DIR=$1
+if [ -z "$TARGET_DIR" ]; then
+  echo "Usage: $0 <target-directory>" >&2
+  exit 1
+fi
+
+if [ -e "$TARGET_DIR" ]; then
+  echo "Error: $TARGET_DIR already exists" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+
+# copy core directories
+cp -r codex "$TARGET_DIR/"
+cp -r docs "$TARGET_DIR/"
+cp README.md "$TARGET_DIR/"
+cp LICENSE.lic "$TARGET_DIR/"
+
+cat <<'MSG'
+Project scaffold created.
+Edit codex/direction.md to define your system goals.
+MSG
+

--- a/codex/progress.md
+++ b/codex/progress.md
@@ -10,3 +10,9 @@
 
 - [added] docs/PROMPTS.md – sample role activation prompts
 - [updated] README.md – referenced PROMPTS guide
+---
+- [added] cli/init.sh – minimal script to scaffold new Codex projects
+- [added] docs/CLI_INIT.md – usage guide for the init script
+- [updated] README.md – added Quick Start section referencing CLI guide
+
+

--- a/docs/CLI_INIT.md
+++ b/docs/CLI_INIT.md
@@ -1,0 +1,18 @@
+# Codex-Hive CLI
+
+This repository includes a minimal script to scaffold a new Codex-based project.
+
+```
+cli/init.sh <target-directory>
+```
+
+The script copies the `codex/` and `docs/` folders, along with `README.md` and `LICENSE.lic`, into the target directory. Use it when you want a quick starting point.
+
+After running the script:
+
+1. Review `codex/direction.md` in the new project and adjust it to your needs.
+2. Update `README.md` to explain your specific goals.
+3. Start logging changes to `codex/progress.md` as you build.
+
+The CLI is intentionally lightweight. Expand or replace it to fit your workflow.
+


### PR DESCRIPTION
## Summary
- add `cli/init.sh` to scaffold a new Codex project
- document the CLI in `docs/CLI_INIT.md`
- reference the init script in `README.md`
- log progress

## Testing
- `bash -n cli/init.sh`
