### PR TITLE
Add roles overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Codex-hive does not run code for you. It provides the scaffolding so humans can 
 - `codex/roles/` – individual role definitions
 - `docs/` – human-facing guides and examples (see `docs/ONBOARDING.md`)
 - `docs/PROMPTS.md` – sample prompts for interacting with Codex roles
+- `docs/ROLES_OVERVIEW.md` – quick summary of all agent roles
 - `docs/RESPONSIBLE_USE.md` – guidelines for safe and responsible use
 - `LICENSE.lic` – released under the Unlicense
 

--- a/codex/progress.md
+++ b/codex/progress.md
@@ -18,3 +18,5 @@
 
 - [added] docs/RESPONSIBLE_USE.md – guidance on safe and responsible use
 - [updated] README.md – linked responsible use guide
+- [added] docs/ROLES_OVERVIEW.md – summarized purpose of each agent
+- [updated] README.md – listed roles overview doc

--- a/docs/ROLES_OVERVIEW.md
+++ b/docs/ROLES_OVERVIEW.md
@@ -1,0 +1,19 @@
+# Codex Roles Overview
+
+This summary helps you understand the purpose of each agent role included in codex-hive. Read the full role files under `codex/roles/` for details.
+
+---
+
+* **Frontman** – first point of contact, translating user prompts and ensuring they reach the right roles.
+* **Orchestrator** – coordinates activity across agents and keeps the system moving.
+* **Planner** – turns open requests into actionable tasks and sequences.
+* **CoreArchitect** – focuses on minimal, sustainable structure in the codebase.
+* **UiDesigner** – designs functional interfaces without unnecessary flair.
+* **ApiLayer** – handles how internal logic is exposed or integrated with other systems.
+* **BundlerAgent** – keeps dependencies lean and packaging simple.
+* **DocWriter** – documents decisions, APIs, and guides for humans.
+* **TestAgent** – writes tests that clarify system behavior and catch regressions.
+* **Guardian** – enforces policy, quality, and safety before anything merges.
+* **VersionAgent** – maintains version numbers and tracks system-level changes.
+
+Use these roles together to keep work structured and transparent.


### PR DESCRIPTION
## Summary
- summarize all agent roles in a single doc
- reference the new overview in README
- log the update in progress

## Testing
- `bash cli/init.sh test_scaffold`