### PR TITLE
Add agent container setup doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Codex-hive does not run code for you. It provides the scaffolding so humans can 
 - `docs/ROLES_OVERVIEW.md` – quick summary of all agent roles
 - `docs/RESPONSIBLE_USE.md` – guidelines for safe and responsible use
 - `docs/WORKFLOW.md` – step-by-step view of how agents collaborate
+- `docs/AGENT_CONTAINER_SETUP.md` – how to prepare a containerized environment
  - `UNLICENSE` – released under the Unlicense
 
 Use `docs/direction.example.md` as inspiration for your own project direction. Log every meaningful change to `codex/progress.md` as you build.
@@ -52,5 +53,6 @@ Use the provided script to scaffold a new project based on codex-hive:
 See `docs/CLI_INIT.md` for details.
 Review `docs/RESPONSIBLE_USE.md` to understand safety expectations.
 Refer to `docs/WORKFLOW.md` for the typical flow of tasks.
+Run `npm install` before starting the agents so required packages are available.
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,0 @@
-- Add to documentation: 'The codex/agent container must run \'npm install\' in it's start-script' 

--- a/codex/progress.md
+++ b/codex/progress.md
@@ -54,3 +54,8 @@
 ---
 [codex] [removed] test/dump-context.test.js – covered by dump-for-context package
 [codex] [removed] vitest dependency – no local tests remaining
+---
+[codex] [added] docs/AGENT_CONTAINER_SETUP.md – instructions for container setup
+[codex] [updated] docs/ONBOARDING.md – added dependency installation step
+[codex] [updated] README.md – referenced container setup doc and install guidance
+[codex] [removed] TODO.md – documentation note addressed

--- a/docs/AGENT_CONTAINER_SETUP.md
+++ b/docs/AGENT_CONTAINER_SETUP.md
@@ -1,0 +1,10 @@
+# Agent Container Setup
+
+This guide describes the minimal steps for running Codex in a containerized environment.
+
+1. Ensure Node.js is available (version 18 or later recommended).
+2. In the container start script, run `npm install` from the project root.
+   This installs the packages required by the repository, such as `dump-for-context`.
+3. After installation, execute the agent or any provided npm scripts.
+
+Adjust your container configuration so that dependencies are installed automatically before the agents run.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -12,7 +12,14 @@ Clone this repository or use it as a template. It provides the basic structure f
 $ git clone https://github.com/Technikhighknee/codex-hive/
 ```
 
-## 2. Review the Core Files
+## 2. Install Dependencies
+
+Run `npm install` in the project root. If you run Codex inside a
+container, make sure the container's start script executes this command so
+all Node-based tools are available. See
+`docs/AGENT_CONTAINER_SETUP.md` for a short setup guide.
+
+## 3. Review the Core Files
 
 - `codex/AGENTS.md` – overview of the team mindset
 - `codex/direction.md` – philosophy and system goals
@@ -21,11 +28,11 @@ $ git clone https://github.com/Technikhighknee/codex-hive/
 
 Understand these before changing anything.
 
-## 3. Define Your Direction
+## 4. Define Your Direction
 
 Create or edit `codex/direction.md` to capture your project's intent. Keep it concise and focused on goals, modules, and documentation expectations.
 
-## 4. Customize Roles if Needed
+## 5. Customize Roles if Needed
 
 Role files live under `codex/roles/`. Update them only if your project requires different responsibilities or behaviors.
 


### PR DESCRIPTION
## Summary
- add AGENT_CONTAINER_SETUP guide and link from README
- mention dependency installation in onboarding docs and quick start
- remove obsolete TODO note
- log progress

## Testing
- `git status --short`