### PR TITLE
Strengthen disclaimers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Use `docs/direction.example.md` as inspiration for your own project direction. L
 
 ## Disclaimer
 
-Codex-hive is an independent, open-source project. It is **not affiliated with OpenAI** and carries no official endorsement. The name "Codex" references OpenAI's technology but does not imply partnership.
+Codex-hive is an independent, open-source project. It is **not affiliated with OpenAI** and carries no official endorsement.
+The name "Codex" references OpenAI's technology but does not imply partnership, nor does this repository contain the Codex model itself.
+Codex-hive only provides scaffolding for projects that wish to use Codex in a role-aware way.
 
 
 ## Quick Start

--- a/URGENT_TODO_FOR_AGENT.md
+++ b/URGENT_TODO_FOR_AGENT.md
@@ -1,3 +1,0 @@
-- make sure we never claim this is codex, but codex-hive!  
-  'codex' uses this. this is codex-hive.  
-  this is important! 

--- a/codex/progress.md
+++ b/codex/progress.md
@@ -66,3 +66,8 @@
 - [codex] [updated] docs/CONTEXT_DUMP.md – clarified dump is for other LLMs
 - [codex] [updated] README.md – noted dump usage with external models
 
+- [codex] [updated] README.md – clarified Codex-hive is scaffolding, not the Codex model
+- [codex] [updated] docs/RESPONSIBLE_USE.md – added note differentiating project from OpenAI Codex
+- [codex] [updated] docs/ONBOARDING.md – explained lack of bundled model
+- [codex] [removed] URGENT_TODO_FOR_AGENT.md – disclaimer addressed
+

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,6 +1,7 @@
 # Getting Started with Codex-Hive
 
 This guide explains how to adapt this repository when creating your own Codex-based project.
+Codex-hive does not include OpenAI's Codex model. It is a template for organizing projects that make use of that technology.
 
 ---
 

--- a/docs/RESPONSIBLE_USE.md
+++ b/docs/RESPONSIBLE_USE.md
@@ -10,4 +10,7 @@ Follow these guidelines to keep your project safe and transparent:
 4. **Respect Privacy** – Do not store sensitive personal data in this repository unless you have explicit consent and clear retention policies.
 5. **Stay Within Scope** – If the project direction changes drastically, update `codex/direction.md` and review all policies.
 
+6. **Remember What This Is** – Codex-hive is a scaffold for working with OpenAI's Codex. It does not contain the Codex model and should never be presented as such.
+
 Codex-Hive provides structure, but you remain responsible for how it is used.
+


### PR DESCRIPTION
## Summary
- clarify that codex-hive is only scaffolding for Codex projects
- stress project identity in the responsible use guide
- note lack of bundled model in onboarding instructions
- remove the leftover TODO file

## Testing
- `git status --short`