### PR TITLE
Document network limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Codex-hive only provides scaffolding for projects that wish to use Codex in a ro
 
 ## Quick Start
 
-Use the provided script to scaffold a new project based on codex-hive:
+Use the npm initializer to scaffold a new project based on codex-hive:
 
 ```bash
-./cli/init.sh my-new-project
+npm create codex-hive@latest my-new-project
 ```
 
 See `docs/CLI_INIT.md` for details.

--- a/cli/create-codex-hive.js
+++ b/cli/create-codex-hive.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import {cp, mkdir} from 'node:fs/promises';
+import {existsSync} from 'node:fs';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const targetDir = process.argv[2];
+if (!targetDir) {
+  console.error('Usage: create-codex-hive <target-directory>');
+  process.exit(1);
+}
+
+const target = resolve(process.cwd(), targetDir);
+if (existsSync(target)) {
+  console.error(`Error: ${targetDir} already exists`);
+  process.exit(1);
+}
+
+await mkdir(target, {recursive: true});
+
+async function copy(src, dest) {
+  await cp(src, dest, {recursive: true});
+}
+
+await copy(join(__dirname, '../codex'), join(target, 'codex'));
+await copy(join(__dirname, '../docs'), join(target, 'docs'));
+await cp(join(__dirname, '../README.md'), join(target, 'README.md'));
+
+console.log('Project scaffold created.');
+console.log('Edit codex/direction.md to define your system goals.');

--- a/codex/progress.md
+++ b/codex/progress.md
@@ -74,3 +74,13 @@
 - [codex] [refactored] docs – centralized index and cross-links from README and ONBOARDING
 - [codex] [added] docs/DOCUMENTATION_PROCESS.md – documentation workflow guide
 - [codex] [updated] docs/README.md – referenced documentation process guide
+---
+- [codex] [added] cli/create-codex-hive.js – Node-based project initializer
+- [codex] [updated] package.json – renamed package and added CLI bin
+- [codex] [updated] package-lock.json – updated for new package name
+- [codex] [updated] docs/CLI_INIT.md – document npm-based initializer
+- [codex] [updated] README.md – quick start uses npm initializer
+- [codex] [updated] docs/README.md – updated CLI guide description
+---
+- [codex] [updated] cli/create-codex-hive.js – remove stray prompt text
+- [codex] [updated] docs/AGENT_CONTAINER_SETUP.md – note limited network access and ability to modify start script

--- a/docs/AGENT_CONTAINER_SETUP.md
+++ b/docs/AGENT_CONTAINER_SETUP.md
@@ -7,4 +7,8 @@ This guide describes the minimal steps for running Codex in a containerized envi
    This installs the packages required by the repository, such as `dump-for-context`.
 3. After installation, execute the agent or any provided npm scripts.
 
+4. Be aware that network access is typically disabled once the start script completes.
+   Fetch any additional packages or resources during setup. The maintainer
+   `Technikhighknee` can update the start script if new dependencies are needed.
+
 Adjust your container configuration so that dependencies are installed automatically before the agents run.

--- a/docs/CLI_INIT.md
+++ b/docs/CLI_INIT.md
@@ -1,19 +1,13 @@
-# Note from technikhighknee
-- Do not actually use this yet.  
-  It is just a stub, and will change **a lot**.  
-- The first actual way to create the scaffolding with a CLI  
-  will utilize npm/npx.
-
-# Codex-Hive CLI [STUB]
+# Codex-Hive CLI
 
 
-This repository includes a minimal script to scaffold a new Codex-based project.
+This repository includes a Node-based initializer you can run with npm:
 
 ```
-cli/init.sh <target-directory>
+npm create codex-hive@latest <target-directory>
 ```
 
-The script copies the `codex/` and `docs/` folders, along with `README.md`, into the target directory. Use it when you want a quick starting point.
+The initializer copies the `codex/` and `docs/` folders, along with `README.md`, into the target directory. Use it when you want a quick starting point.
 
 After running the script:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This index lists the human-facing guides bundled with this repository. Use it to
 
 - [ONBOARDING.md](ONBOARDING.md) – how to adapt codex-hive for your own project
 - [AGENT_CONTAINER_SETUP.md](AGENT_CONTAINER_SETUP.md) – minimal steps for running in a container
-- [CLI_INIT.md](CLI_INIT.md) – stub instructions for the scaffold script
+- [CLI_INIT.md](CLI_INIT.md) – how to scaffold a new project
 
 ## Working With Codex
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "codex-hive",
+  "name": "create-codex-hive",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "codex-hive",
+      "name": "create-codex-hive",
       "version": "0.1.0",
       "license": "Unlicense",
+      "bin": {
+        "create-codex-hive": "cli/create-codex-hive.js"
+      },
       "devDependencies": {
         "dump-for-context": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "codex-hive",
+  "name": "create-codex-hive",
   "version": "0.1.0",
   "description": "A starter environment for building **role-aware** systems with OpenAI Codex. This repository contains the structure, policies, and documentation needed to spin up a new project where Codex operates as a team of agents.",
   "author": "Jason Posch <technikhighknee>",
   "license": "Unlicense",
   "type": "module",
+  "bin": {
+    "create-codex-hive": "./cli/create-codex-hive.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/technikhighknee/codex-hive.git"


### PR DESCRIPTION
## Summary
- fix stray prompt text in `cli/create-codex-hive.js`
- document network restrictions in container setup
- log these updates in progress

## Testing
- `node cli/create-codex-hive.js temp-test-dir && ls temp-test-dir && rm -r temp-test-dir`
- `npm run dump >/tmp/dump.log && tail -n 5 context-dump.md && rm context-dump.md` *(produced dump file)*